### PR TITLE
Patch for RegEx DoS exploit

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "dependencies": {
     "browser-request": "~0.3.0",
-    "debug": "^2.1.0",
+    "debug": "^2.6.9",
     "request": "^2.83.0"
   },
   "devDependencies": {


### PR DESCRIPTION
From https://nodesecurity.io/advisories/534 :

OVERVIEW

Affected versions of debug are vulnerable to regular expression denial of service when untrusted user input is passed into the o formatter.

As it takes 50,000 characters to block the event loop for 2 seconds, this issue is a low severity issue.


REMEDIATION

Version 2.x.x: Update to version 2.6.9 or later. Version 3.x.x: Update to version 3.1.0 or later.